### PR TITLE
Fix incompatible pointer compilation error

### DIFF
--- a/src/0x02/control.c
+++ b/src/0x02/control.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 	puts("Overflow the buffer! Set the return address.");
 	printf("The return address for the shell function is @ %p\n", &shell);
 
-	gets(&buffer);
+	gets(buffer);
 
 	return 0;
 }


### PR DESCRIPTION
`gets()` takes in `char *` instead of `char **`.

Closes #2.